### PR TITLE
🏗️ Implement layer communication rules with ESLint enforcement

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -25,6 +25,7 @@ src/lib/
 │   │   ├── home/        # Home page components
 │   │   └── layout/      # Layout components
 │   └── ui/              # Reusable UI components (shadcn-svelte)
+├── composables/         # Reusable reactive logic and state management
 ├── constants/           # Application constants
 ├── helpers/             # Business logic and API operations (comment handling, authentication, etc.)
 ├── schemas/             # Zod validation schemas
@@ -32,6 +33,11 @@ src/lib/
 ├── types/               # TypeScript type definitions
 └── utils/               # Generic utility functions (reusable, not feature-specific)
 ```
+
+**Layer Communication Rules**:
+
+- **Components**: Access Helpers via Stores (direct Helper dependency is prohibited)
+- **Stores/Composables**: Can directly access Helpers, pass state to Helpers for execution
 
 [[Demo](https://webapp-template.usagizmo.com/)]
 

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -3,6 +3,7 @@ import { base, svelte } from '@repo/eslint-config';
 export default [
   ...base,
   ...svelte,
+  // Direct import from Stores layer is prohibited
   {
     rules: {
       'no-restricted-imports': [
@@ -12,6 +13,23 @@ export default [
             {
               group: ['$lib/stores/*', '!$lib/stores/index.ts'],
               message: 'Import from `$lib/stores`',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  // Direct dependency on Helpers in Components layer is prohibited
+  {
+    files: ['src/lib/components/**/*.svelte', 'src/routes/**/*.svelte'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['$lib/helpers/**'],
+              message: 'Access Helpers layer via Stores/Composables',
             },
           ],
         },

--- a/apps/web/src/lib/composables/useCounter.svelte.ts
+++ b/apps/web/src/lib/composables/useCounter.svelte.ts
@@ -1,0 +1,13 @@
+export const useCounter = () => new Counter();
+
+class Counter {
+  #count = $state(0);
+
+  get count() {
+    return this.#count;
+  }
+
+  increment() {
+    this.#count += 1;
+  }
+}

--- a/apps/web/src/lib/stores/UserStore.svelte.ts
+++ b/apps/web/src/lib/stores/UserStore.svelte.ts
@@ -95,6 +95,13 @@ export class UserStore {
   }
 
   /**
+   * Fetch user profile information
+   */
+  async fetchUserProfile(userId: string) {
+    return await supabaseHelpers.fetchUserProfile(this.#supabaseStore.client, userId);
+  }
+
+  /**
    * Update user profile information (with store update)
    */
   async updateUserProfile(updates: TablesUpdate<'profiles'>): Promise<{ error: Error | null }> {

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -9,7 +9,6 @@
   import GA4 from '$lib/components/pages/layout/GA4.svelte';
   import HeaderNavigation from '$lib/components/pages/layout/HeaderNavigation.svelte';
   import { Toaster } from '$lib/components/ui/sonner';
-  import { fetchUserProfile } from '$lib/helpers/supabaseHelpers';
   import { supabaseStore, userStore } from '$lib/stores';
 
   import type { LayoutProps } from './$types';
@@ -39,7 +38,7 @@
 
       let newProfile = null;
       if (newUser) {
-        const { profile: fetchedProfile } = await fetchUserProfile(supabase, newUser.id);
+        const { profile: fetchedProfile } = await userStore.fetchUserProfile(newUser.id);
         newProfile = fetchedProfile;
       }
 


### PR DESCRIPTION
## Summary

- Implement layer communication rules to enforce architectural constraints
- Add ESLint rules to prohibit direct Helper access from Components layer
- Document layer communication rules in README.md

## Changes

- **ESLint Configuration**: Added rules to prevent Components from directly importing Helpers
- **UserStore Enhancement**: Added `fetchUserProfile` method to provide Helper access via Store
- **Layout Component**: Updated `+layout.svelte` to use Store method instead of direct Helper import
- **Documentation**: Added layer communication rules section to README.md
- **Composables**: Added example `useCounter.svelte.ts` for composables directory

## Test plan

- [x] ESLint rules enforce layer communication constraints
- [x] All existing tests pass
- [x] No direct Helper imports in Components layer
- [x] Store methods provide proper Helper access