### PR TITLE
🧪 Add Supabase database testing functionality

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -9,41 +9,25 @@ pnpm start      # Start Supabase locally
 pnpm stop       # Stop Supabase
 pnpm status     # Show Supabase service status
 pnpm reset      # Reset database and regenerate types
-pnpm diff       # Show schema changes
-pnpm push       # Push migrations to remote
-pnpm pull       # Pull schema changes from remote and regenerate types
-pnpm migration  # Create new migration file
-pnpm link       # Link to remote project
-pnpm seed       # Seed storage buckets
 pnpm generate   # Generate TypeScript types
+pnpm test       # Run database tests
 ```
 
-## Development Setup
+For additional Supabase CLI commands and usage, see the [official CLI reference](https://supabase.com/docs/reference/cli/introduction).
 
-1. Start Supabase: `pnpm start`
-2. Access Supabase Studio: http://localhost:54323
-3. Generate types after schema changes: `pnpm generate`
-
-## Development Workflow
-
-### Basic Workflow
+## Development
 
 1. `pnpm start` - Start Supabase
-2. Make schema changes in Studio (http://localhost:54323)
-3. `pnpm diff` - Generate migration from changes
-4. `pnpm generate` - Update TypeScript types
+2. Access Studio: http://localhost:54323
+3. `pnpm generate` - Update types after schema changes
 
-### Migration Workflow
+## Testing
 
-1. `pnpm migration <name>` - Create new migration file
-2. Edit the migration file with SQL
-3. `pnpm reset` - Apply migrations and regenerate types
+```bash
+pnpm test  # Run all database tests (requires Supabase running)
+```
 
-### Remote Sync
-
-1. `pnpm link` - Link to remote project (first time only)
-2. `pnpm pull` - Pull remote schema changes
-3. `pnpm push` - Push local migrations to remote
+Test files in `supabase/tests/` cover database schema, CRUD operations, RLS policies, and triggers.
 
 ## Port Numbers
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,14 +11,9 @@
     "stop": "pnpm exec supabase stop",
     "status": "pnpm exec supabase status",
     "reset": "pnpm exec supabase db reset && pnpm generate",
-    "diff": "pnpm exec supabase db diff",
-    "push": "pnpm exec supabase db push",
-    "pull": "pnpm exec supabase db pull && pnpm generate",
-    "migration": "pnpm exec supabase migration new",
-    "link": "pnpm exec supabase link",
-    "seed": "pnpm exec supabase seed buckets",
+    "generate:supabase-types": "mkdir -p \\$generated && pnpm exec supabase gen types typescript --local > ./\\$generated/types.ts",
     "generate": "pnpm generate:supabase-types",
-    "generate:supabase-types": "mkdir -p \\$generated && pnpm exec supabase gen types typescript --local > ./\\$generated/types.ts"
+    "test": "pnpm exec supabase test db"
   },
   "devDependencies": {
     "supabase": "^2.30.4"

--- a/apps/api/supabase/tests/auth_and_rls.sql
+++ b/apps/api/supabase/tests/auth_and_rls.sql
@@ -1,0 +1,172 @@
+-- Test authentication and Row Level Security (RLS) policies
+BEGIN;
+SELECT plan(15);
+
+-- Create test users
+INSERT INTO auth.users (
+    id, 
+    email, 
+    encrypted_password, 
+    email_confirmed_at, 
+    created_at, 
+    updated_at,
+    raw_user_meta_data
+) VALUES 
+(
+    '550e8400-e29b-41d4-a716-446655440001',
+    'user1@example.com',
+    '$2a$10$test.hash.here',
+    NOW(),
+    NOW(), 
+    NOW(),
+    '{"display_name": "User One"}'::jsonb
+),
+(
+    '550e8400-e29b-41d4-a716-446655440002',
+    'user2@example.com',
+    '$2a$10$test.hash.here',
+    NOW(),
+    NOW(), 
+    NOW(),
+    '{"display_name": "User Two"}'::jsonb
+);
+
+-- Test RLS policies exist
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_policies 
+        WHERE tablename = 'profiles' 
+        AND policyname = 'Users can view all profiles'
+    ),
+    'RLS policy "Users can view all profiles" exists'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_policies 
+        WHERE tablename = 'profiles' 
+        AND policyname = 'Users can update their own profile'
+    ),
+    'RLS policy "Users can update their own profile" exists'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_policies 
+        WHERE tablename = 'profiles' 
+        AND policyname = 'Users can insert their own profile'
+    ),
+    'RLS policy "Users can insert their own profile" exists'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_policies 
+        WHERE tablename = 'comments' 
+        AND policyname = 'Users can view all comments'
+    ),
+    'RLS policy "Users can view all comments" exists'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_policies 
+        WHERE tablename = 'comments' 
+        AND policyname = 'Users can insert their own comments'
+    ),
+    'RLS policy "Users can insert their own comments" exists'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_policies 
+        WHERE tablename = 'comments' 
+        AND policyname = 'Users can update their own comments'
+    ),
+    'RLS policy "Users can update their own comments" exists'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_policies 
+        WHERE tablename = 'comments' 
+        AND policyname = 'Users can delete their own comments'
+    ),
+    'RLS policy "Users can delete their own comments" exists'
+);
+
+-- Test storage policies exist
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_policies 
+        WHERE tablename = 'objects' 
+        AND schemaname = 'storage'
+        AND policyname = 'Users can upload files to comments bucket'
+    ),
+    'Storage policy "Users can upload files to comments bucket" exists'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_policies 
+        WHERE tablename = 'objects' 
+        AND schemaname = 'storage'
+        AND policyname = 'Users can view files in comments bucket'
+    ),
+    'Storage policy "Users can view files in comments bucket" exists'
+);
+
+-- Test handle_new_user function exists
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_proc 
+        WHERE proname = 'handle_new_user'
+    ),
+    'Function handle_new_user exists'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_proc 
+        WHERE proname = 'update_updated_at_column'
+    ),
+    'Function update_updated_at_column exists'
+);
+
+-- Test triggers exist
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_trigger 
+        WHERE tgname = 'on_auth_user_created'
+    ),
+    'Trigger on_auth_user_created exists'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_trigger 
+        WHERE tgname = 'update_profiles_updated_at'
+    ),
+    'Trigger update_profiles_updated_at exists'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_trigger 
+        WHERE tgname = 'update_comments_updated_at'  
+    ),
+    'Trigger update_comments_updated_at exists'
+);
+
+-- Test realtime publication
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM pg_publication_tables 
+        WHERE pubname = 'supabase_realtime' 
+        AND tablename = 'profiles'
+    ),
+    'Profiles table added to realtime publication'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/apps/api/supabase/tests/crud_operations.sql
+++ b/apps/api/supabase/tests/crud_operations.sql
@@ -1,0 +1,89 @@
+-- Test CRUD operations for profiles and comments
+BEGIN;
+SELECT plan(9);
+
+-- Create test user in auth.users first
+INSERT INTO auth.users (
+    id, 
+    email, 
+    encrypted_password, 
+    email_confirmed_at, 
+    created_at, 
+    updated_at,
+    raw_user_meta_data
+) VALUES (
+    '550e8400-e29b-41d4-a716-446655440000',
+    'test@example.com',
+    '$2a$10$test.hash.here',
+    NOW(),
+    NOW(), 
+    NOW(),
+    '{"display_name": "Test User"}'::jsonb
+);
+
+-- Test profile creation via trigger
+SELECT ok(
+    EXISTS(SELECT 1 FROM profiles WHERE id = '550e8400-e29b-41d4-a716-446655440000'),
+    'Profile created automatically via trigger'
+);
+
+-- Test profile data integrity
+SELECT ok(
+    (SELECT email FROM profiles WHERE id = '550e8400-e29b-41d4-a716-446655440000') = 'test@example.com',
+    'Profile email matches user email'
+);
+
+SELECT ok(
+    (SELECT display_name FROM profiles WHERE id = '550e8400-e29b-41d4-a716-446655440000') = 'Test User',
+    'Profile display_name set from metadata'
+);
+
+-- Test profile update
+UPDATE profiles 
+SET display_name = 'Updated User', bio = 'Test bio'
+WHERE id = '550e8400-e29b-41d4-a716-446655440000';
+
+SELECT ok(
+    (SELECT display_name FROM profiles WHERE id = '550e8400-e29b-41d4-a716-446655440000') = 'Updated User',
+    'Profile display_name updated successfully'
+);
+
+SELECT ok(
+    (SELECT bio FROM profiles WHERE id = '550e8400-e29b-41d4-a716-446655440000') = 'Test bio',
+    'Profile bio updated successfully' 
+);
+
+-- Test comment creation
+INSERT INTO comments (user_id, text, file_path)
+VALUES ('550e8400-e29b-41d4-a716-446655440000', 'Test comment', '/test/file.txt');
+
+SELECT ok(
+    EXISTS(SELECT 1 FROM comments WHERE user_id = '550e8400-e29b-41d4-a716-446655440000'),
+    'Comment created successfully'
+);
+
+SELECT ok(
+    (SELECT text FROM comments WHERE user_id = '550e8400-e29b-41d4-a716-446655440000') = 'Test comment',
+    'Comment text stored correctly'
+);
+
+-- Test comment update
+UPDATE comments 
+SET text = 'Updated comment text'
+WHERE user_id = '550e8400-e29b-41d4-a716-446655440000';
+
+SELECT ok(
+    (SELECT text FROM comments WHERE user_id = '550e8400-e29b-41d4-a716-446655440000') = 'Updated comment text',
+    'Comment text updated successfully'
+);
+
+-- Test cascade delete (comment should be deleted when profile is deleted)
+DELETE FROM auth.users WHERE id = '550e8400-e29b-41d4-a716-446655440000';
+
+SELECT ok(
+    NOT EXISTS(SELECT 1 FROM profiles WHERE id = '550e8400-e29b-41d4-a716-446655440000'),
+    'Profile deleted via cascade from auth.users'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/apps/api/supabase/tests/database_basics.sql
+++ b/apps/api/supabase/tests/database_basics.sql
@@ -1,0 +1,70 @@
+-- Test basic database connectivity and schema
+BEGIN;
+SELECT plan(10);
+
+-- Test database connection
+SELECT ok(current_database() = 'postgres', 'Database connection established');
+
+-- Test required extensions
+SELECT ok(
+    EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'uuid-ossp'),
+    'UUID extension is installed'
+);
+
+-- Test tables exist
+SELECT ok(
+    EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'profiles'),
+    'Profiles table exists'
+);
+
+SELECT ok(
+    EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'comments'),
+    'Comments table exists'  
+);
+
+-- Test table structure for profiles
+SELECT ok(
+    (SELECT COUNT(*) FROM information_schema.columns 
+     WHERE table_name = 'profiles' AND column_name IN ('id', 'email', 'display_name', 'bio', 'created_at', 'updated_at')) = 6,
+    'Profiles table has correct columns'
+);
+
+-- Test table structure for comments  
+SELECT ok(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_name = 'comments' AND column_name IN ('id', 'user_id', 'text', 'file_path', 'created_at', 'updated_at')) = 6,
+    'Comments table has correct columns'
+);
+
+-- Test RLS is enabled
+SELECT ok(
+    (SELECT relrowsecurity FROM pg_class WHERE relname = 'profiles'),
+    'RLS is enabled on profiles table'
+);
+
+SELECT ok(
+    (SELECT relrowsecurity FROM pg_class WHERE relname = 'comments'),
+    'RLS is enabled on comments table'
+);
+
+-- Test foreign key constraints
+SELECT ok(
+    EXISTS(
+        SELECT 1 FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu 
+        ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.table_name = 'profiles' 
+        AND tc.constraint_type = 'FOREIGN KEY'
+        AND kcu.column_name = 'id'
+    ),
+    'Profiles table has foreign key constraint on id'
+);
+
+-- Test storage bucket exists
+SELECT ok(
+    EXISTS(SELECT 1 FROM storage.buckets WHERE name = 'comments'),
+    'Comments storage bucket exists'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/apps/api/supabase/tests/functions_and_triggers.sql
+++ b/apps/api/supabase/tests/functions_and_triggers.sql
@@ -1,0 +1,88 @@
+-- Test database functions and triggers behavior
+BEGIN;
+SELECT plan(5);
+
+-- Test handle_new_user function behavior
+-- Create a user without profile first (simulating auth signup)
+INSERT INTO auth.users (
+    id, 
+    email, 
+    encrypted_password, 
+    email_confirmed_at, 
+    created_at, 
+    updated_at,
+    raw_user_meta_data
+) VALUES (
+    '550e8400-e29b-41d4-a716-446655440003',
+    'trigger-test@example.com',
+    '$2a$10$test.hash.here',
+    NOW(),
+    NOW(), 
+    NOW(),
+    '{"display_name": "Trigger Test User"}'::jsonb
+);
+
+-- Test that profile was created automatically
+SELECT ok(
+    EXISTS(SELECT 1 FROM profiles WHERE id = '550e8400-e29b-41d4-a716-446655440003'),
+    'Profile created automatically when user is inserted'
+);
+
+SELECT ok(
+    (SELECT email FROM profiles WHERE id = '550e8400-e29b-41d4-a716-446655440003') = 'trigger-test@example.com',
+    'Profile email matches auth user email'
+);
+
+SELECT ok(
+    (SELECT display_name FROM profiles WHERE id = '550e8400-e29b-41d4-a716-446655440003') = 'Trigger Test User',
+    'Profile display_name extracted from user metadata'
+);
+
+-- Test default display_name for user without metadata
+INSERT INTO auth.users (
+    id, 
+    email, 
+    encrypted_password, 
+    email_confirmed_at, 
+    created_at, 
+    updated_at
+) VALUES (
+    '550e8400-e29b-41d4-a716-446655440004',
+    'no-metadata@example.com',
+    '$2a$10$test.hash.here',
+    NOW(),
+    NOW(), 
+    NOW()
+);
+
+SELECT ok(
+    (SELECT display_name FROM profiles WHERE id = '550e8400-e29b-41d4-a716-446655440004') = 'Anonymous User',
+    'Default display_name used when metadata is missing'
+);
+
+-- Test function with edge case - user with malformed metadata
+INSERT INTO auth.users (
+    id, 
+    email, 
+    encrypted_password, 
+    email_confirmed_at, 
+    created_at, 
+    updated_at,
+    raw_user_meta_data
+) VALUES (
+    '550e8400-e29b-41d4-a716-446655440005',
+    'malformed@example.com',
+    '$2a$10$test.hash.here',
+    NOW(),
+    NOW(), 
+    NOW(),
+    '{"other_field": "value"}'::jsonb  -- no display_name field
+);
+
+SELECT ok(
+    (SELECT display_name FROM profiles WHERE id = '550e8400-e29b-41d4-a716-446655440005') = 'Anonymous User',
+    'Default display_name used when display_name field is missing from metadata'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/project-words.txt
+++ b/project-words.txt
@@ -5,6 +5,7 @@ cdate
 dirents
 dotenvx
 esbuild
+extname
 fkey
 formsnap
 hasura
@@ -17,9 +18,16 @@ markuplintrc
 nhost
 noto
 oklch
+ossp
 pooler
 postgrest
+proname
+pubname
+relname
+relrowsecurity
+schemaname
 shadcn
+signup
 snakecase
 sonner
 sssz
@@ -27,6 +35,7 @@ supabase
 superforms
 sveltejs
 tailwindcss
+tgname
 tseslint
 turborepo
 usagizmo


### PR DESCRIPTION
## Summary

- Add comprehensive SQL test files for database schema validation (39 test cases)
- Include tests for authentication, RLS policies, CRUD operations, and database triggers
- Simplify API documentation and package.json scripts
- Add `pnpm test` command for running database tests

## Changes

### New Test Files
- `apps/api/supabase/tests/database_basics.sql` - Basic connectivity and schema validation (10 tests)
- `apps/api/supabase/tests/auth_and_rls.sql` - Authentication and RLS policies validation (15 tests)
- `apps/api/supabase/tests/crud_operations.sql` - CRUD operations testing (9 tests)
- `apps/api/supabase/tests/functions_and_triggers.sql` - Database functions and triggers testing (5 tests)

### Documentation Updates
- Streamlined `apps/api/README.md` with clearer development workflow
- Updated `apps/api/package.json` with test command and simplified scripts

### Test Coverage
✅ Database connectivity and extensions  
✅ Table structure and constraints  
✅ Row Level Security (RLS) policies  
✅ Storage bucket policies  
✅ Authentication triggers and functions  
✅ CRUD operations and data integrity  
✅ Cascade delete operations  
✅ Edge cases and error handling  

## Test Plan

- [x] All 39 database tests pass locally
- [x] Existing CI tests continue to pass (API tests excluded from GitHub Actions)
- [x] Documentation accurately reflects new test commands
- [x] CSpell configuration updated for PostgreSQL terminology

## Usage

```bash
cd apps/api
pnpm start  # Start Supabase locally
pnpm test   # Run database tests
```