### PR TITLE
🔧 Include .github directory in cspell check

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "turbo run dev",
     "preview": "turbo run preview",
     "lint:root": "run-p lint:cspell lint:prettier",
-    "lint:cspell": "cspell --exclude \"apps/**/*\" --exclude \"packages/**/*\" \"**/*\"",
+    "lint:cspell": "cspell --exclude \"apps/**/*\" --exclude \"packages/**/*\" \".github/**/*\" \"**/*\"",
     "lint:prettier": "prettier . --check --ignore-path=.prettierignore.root",
     "lint:packages": "turbo run lint",
     "lint": "run-p lint:root lint:packages",


### PR DESCRIPTION
## Changes
- Add `.github/**/*` to cspell check targets in `lint:cspell` script

## Description
This PR adds the `.github` directory to the cspell check targets, ensuring that GitHub workflow files and other GitHub-related files are also checked for spelling errors.