### PR TITLE
🔧 Add architecture rule to prevent Helpers/Utility layers from depending on Stores layer

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -38,6 +38,7 @@ src/lib/
 
 - **Components**: Access Helpers via Stores/LocalStores (direct Helper dependency is prohibited)
 - **Stores/LocalStores**: Can directly access Helpers, pass state to Helpers for execution
+- **Helpers/Utility**: Cannot depend on Stores (must be pure functions, receive values as arguments)
 
 ## State Management
 

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -36,4 +36,21 @@ export default [
       ],
     },
   },
+  // Helpers and Utility layers cannot depend on Stores layer
+  {
+    files: ['src/lib/helpers/**/*.ts', 'src/lib/utility/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['$lib/stores', '$lib/stores/**'],
+              message: 'Pass values as arguments to keep Helpers/Utility pure functions',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -46,6 +46,7 @@ export default pages;
 - **Prettier Integration** - Seamless integration with Prettier formatting
 - **Test File Detection** - Automatic relaxed rules for `*.test.{js,ts}` and `*.spec.{js,ts}`
 - **Config File Detection** - Relaxed JSDoc requirements for `*.config.{js,ts}`
+- **Architecture Rules** - Layered architecture enforcement (available in `web` config)
 
 ## Included Plugins
 
@@ -63,6 +64,22 @@ export default pages;
 bun lint    # Run linting
 bun format  # Format code
 ```
+
+## Architecture Rules (Web Config)
+
+The `web` configuration includes architectural layer rules to enforce clean separation of concerns:
+
+### Layer Restrictions
+
+- **Stores Layer Access**: Direct imports from `$lib/stores/*` are prohibited; use `$lib/stores` index
+- **Components Layer**: Cannot directly import Helpers; must access via Stores/LocalStores
+- **Helpers/Utility Layers**: Cannot import from Stores layer; must be pure functions receiving values as arguments
+
+These rules ensure:
+
+- **Testability**: Pure functions in Helpers/Utility layers are easy to test without mocking
+- **Maintainability**: Clear separation of concerns and unidirectional data flow
+- **Type Safety**: Dependency injection through function arguments provides better type inference
 
 ## Design Philosophy
 


### PR DESCRIPTION
- Add ESLint rule to prohibit Stores layer imports in Helpers/Utility layers
- Update README files to document the new architecture rule
- Enforce pure function pattern by requiring values to be passed as arguments