### PR TITLE
🔧 Fix ESLint layer naming to match actual directory structure

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -38,7 +38,7 @@ src/lib/
 
 - **Components**: Access Helpers via Stores/LocalStores (direct Helper dependency is prohibited)
 - **Stores/LocalStores**: Can directly access Helpers, pass state to Helpers for execution
-- **Helpers/Utility**: Cannot depend on Stores (must be pure functions, receive values as arguments)
+- **Helpers/Utils**: Cannot depend on Stores (must be pure functions, receive values as arguments)
 
 ## State Management
 

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -36,9 +36,9 @@ export default [
       ],
     },
   },
-  // Helpers and Utility layers cannot depend on Stores layer
+  // Helpers and Utils layers cannot depend on Stores layer
   {
-    files: ['src/lib/helpers/**/*.ts', 'src/lib/utility/**/*.ts'],
+    files: ['src/lib/helpers/**/*.ts', 'src/lib/utils/**/*.ts'],
     rules: {
       'no-restricted-imports': [
         'error',
@@ -46,7 +46,7 @@ export default [
           patterns: [
             {
               group: ['$lib/stores', '$lib/stores/**'],
-              message: 'Pass values as arguments to keep Helpers/Utility pure functions',
+              message: 'Pass values as arguments to keep Helpers/Utils pure functions',
             },
           ],
         },

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -73,11 +73,11 @@ The `web` configuration includes architectural layer rules to enforce clean sepa
 
 - **Stores Layer Access**: Direct imports from `$lib/stores/*` are prohibited; use `$lib/stores` index
 - **Components Layer**: Cannot directly import Helpers; must access via Stores/LocalStores
-- **Helpers/Utility Layers**: Cannot import from Stores layer; must be pure functions receiving values as arguments
+- **Helpers/Utils Layers**: Cannot import from Stores layer; must be pure functions receiving values as arguments
 
 These rules ensure:
 
-- **Testability**: Pure functions in Helpers/Utility layers are easy to test without mocking
+- **Testability**: Pure functions in Helpers/Utils layers are easy to test without mocking
 - **Maintainability**: Clear separation of concerns and unidirectional data flow
 - **Type Safety**: Dependency injection through function arguments provides better type inference
 


### PR DESCRIPTION
## Summary

This PR updates ESLint configuration and documentation to use the correct layer name `utils` instead of the outdated `utility` reference.

## Changes

- Updated ESLint config file patterns from `src/lib/utility/**/*.ts` to `src/lib/utils/**/*.ts`
- Updated comments and error messages to reference `Helpers/Utils` instead of `Helpers/Utility`
- Updated README documentation to reflect the correct naming convention

## Context

The directory structure was already renamed from `utility` to `utils`, but the ESLint configuration and documentation still referenced the old name. This PR aligns the configuration with the actual directory structure.

## Files Changed

- `apps/web/eslint.config.js` - Updated file patterns and comments
- `apps/web/README.md` - Updated layer naming documentation
- `packages/eslint-config/README.md` - Updated architectural layer documentation