### PR TITLE
👷 Update CI tooling config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,61 +1,46 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches:
       - main
   pull_request:
     branches:
       - main
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-
-    name: Build (Bun on ${{ matrix.os }})
-
-    # The type of runner that the job will run on
-    runs-on: ${{ matrix.os }}
+    name: Build
+    runs-on: ubuntu-latest
     timeout-minutes: 8
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: 🛎 Checkout
         uses: actions/checkout@v4
 
       - name: 📦 Setup Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
 
       - name: 👨🏻‍💻 Install dependencies
         run: bun install --frozen-lockfile
 
       - name: 🐣 Run build
-        run: bun turbo build --filter !api
+        run: bun turbo build --filter='!api'
         env:
           PUBLIC_GA4_MEASUREMENT_ID: ${{ secrets.PUBLIC_GA4_MEASUREMENT_ID }}
           PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
           PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PUBLIC_SUPABASE_ANON_KEY }}
 
       - name: 👀 Run lint
-        run: bun lint
+        run: bun run lint
 
       - name: 🧪 Run test
-        run: bun turbo test --filter !api
+        run: bun turbo test --filter='!api'

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,9 @@
       "dependsOn": ["@repo/shared#build"],
       "outputs": [".svelte-kit/**", ".vercel/**"]
     },
+    "web#lint": {
+      "dependsOn": ["@repo/shared#build"]
+    },
     "@repo/shared#build": {
       "outputs": [".svelte-kit/**", "dist/**"]
     },


### PR DESCRIPTION
## Summary
- Use the Bun version from packageManager in GitHub Actions setup
- Restrict workflow token permissions to read-only contents access
- Ensure web lint builds the shared package before resolving shared component types

## Verification
- bun format
- bun run lint
- bun turbo build --filter='!api'
- bun turbo test --filter='!api'